### PR TITLE
Remove client-side routing

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -12,9 +12,7 @@ export default function Breadcrumbs({ items }: Props) {
           if (href) {
             return (
               <li key={text} className="breadcrumbs__item">
-                <Link href={href}>
-                  <a className="breadcrumbs__link">{text}</a>
-                </Link>
+                <a className="breadcrumbs__link" href={href}>{text}</a>
               </li>
             )
           } else {

--- a/components/CategoryNav.tsx
+++ b/components/CategoryNav.tsx
@@ -32,9 +32,7 @@ export default function CategoryNav({ categoryInfo }: Props) {
             });
             return (
               <li className="category-nav__item" key={href}>
-                <Link href={href}>
-                  <a className={className}>{text}</a>
-                </Link>
+                <a className={className} href={href}>{text}</a>
               </li>
             )
           })

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,11 +5,9 @@ import Nav from './Nav';
 export default function Header() {
   return (
     <header className="header">
-      <Link href="/">
-        <a className="header__link" tabIndex={-1} aria-hidden="true">
-          <img src="/svgs/logo.svg" alt="Roseate Cards" className="header__logo" width="250px" />
-        </a>
-      </Link>
+      <a className="header__link" href="/" tabIndex={-1} aria-hidden="true">
+        <img src="/svgs/logo.svg" alt="Roseate Cards" className="header__logo" width="250px" />
+      </a>
       <Nav />
     </header>
   )

--- a/components/ProductItem.tsx
+++ b/components/ProductItem.tsx
@@ -6,15 +6,13 @@ const NEW_IS_WITHIN_DAYS = 21;
 export default function ProductItem({ id, title, price, images, created, type }: Product) {
   const isNew = ((new Date()).getTime() - created) < NEW_IS_WITHIN_DAYS * 24 * 60 * 60 * 1000;
   return (
-    <Link href={id}>
-      <a className="product-item" aria-label={`${title}${type ? ` ${type}` : ''}. £${price}`}>
-        {isNew && <p className="product-item__new">New!</p>}
-        <div className="product-item__image-wrapper">
-          <img src={images[0].url_570xN} className="product-item__image" alt={images[0].description} />
-        </div>
-        <p className="product-item__title">{title}</p>
-        <p className="product-item__price">&pound;{price}</p>
-      </a>
-    </Link>
+    <a className="product-item" href={id} aria-label={`${title}${type ? ` ${type}` : ''}. £${price}`}>
+      {isNew && <p className="product-item__new">New!</p>}
+      <div className="product-item__image-wrapper">
+        <img src={images[0].url_570xN} className="product-item__image" alt={images[0].description} />
+      </div>
+      <p className="product-item__title">{title}</p>
+      <p className="product-item__price">&pound;{price}</p>
+    </a>
   )
 }

--- a/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
+++ b/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
@@ -40,11 +40,9 @@ export default function ProductPage({
         <div className="gel-layout__item gel-1/2@m">
           <h1 className="page-title product-page__title">{product.title}</h1>
           <p className="product-page__price">£{product.price}</p>
-          <Link href={product.url}>
-            <a className="product-page__buy">
-              Buy on Etsy
-            </a>
-          </Link>
+          <a className="product-page__buy" href={product.url}>
+            Buy on Etsy
+          </a>
           <p className="product-page__description">
             {htmlParser(product.description.replace(/\n/g, '<br />'))}
           </p>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <div className="page-container">
         <a href="#main" className="skiplink">Skip to main page content</a>
         <Header />
-        <main id="main" role="main" aria-live="assertive">
+        <main id="main" role="main">
           <Component {...pageProps} />
         </main>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,18 +6,14 @@ export default function Home() {
 
       <h1 className="screenreader-only">Welcome to Roseate Cards</h1>
 
-      <Link href="/cards/christmas">
-        <a className="home-page__featured">
-          <p className="home-page__featured-text-wrapper">
-            <span className="home-page__featured-text">It's beginning to look a lot like</span><br/><span className="home-page__featured-text home-page__featured-large-text">Christmas</span>
-          </p>
-        </a>
-      </Link>
+      <a className="home-page__featured" href="/cards/christmas">
+        <p className="home-page__featured-text-wrapper">
+          <span className="home-page__featured-text">It's beginning to look a lot like</span><br/><span className="home-page__featured-text home-page__featured-large-text">Christmas</span>
+        </p>
+      </a>
 
       <div className="home-page__covid-banner"><strong>COVID-19 update:</strong> we're still open;&nbsp;
-        <Link href="/contact#covid19">
-          <a>shipping may be delayed</a>
-        </Link>
+        <a href="/contact#covid19">shipping may be delayed</a>
       </div>
 
       <div className="home-page__info gel-layout">


### PR DESCRIPTION
Remove client-side routing for now because Next.js does not announce anything when navigating to a new page. We have a [potential solution/workaround](https://github.com/vanitabarrett/roseatecards.co.uk/tree/improved-screenreader-for-client-side-routing) but it needs more testing - it reads the whole page content out which doesn't feel ideal either. 