### PR TITLE
Add structured data

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 interface Props {
   items: { text: string, href?: string }[]
 }

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -4,19 +4,21 @@ interface Props {
 
 export default function Breadcrumbs({ items }: Props) {
   return (
-    <ol className="breadcrumbs">
+    <ol className="breadcrumbs" itemScope itemType="https://schema.org/BreadcrumbList">
       {
-        items.map(({ text, href }) => {
+        items.map(({ text, href }, index) => {
           if (href) {
             return (
-              <li key={text} className="breadcrumbs__item">
-                <a className="breadcrumbs__link" href={href}>{text}</a>
+              <li key={text} className="breadcrumbs__item" itemProp="itemListElement" itemScope  itemType="https://schema.org/ListItem">
+                <a className="breadcrumbs__link" href={href} itemProp="item"><span itemProp="name">{text}</span></a>
+                <meta itemProp="position" content={`${index + 1}`} />
               </li>
             )
           } else {
             return (
-              <li key={text} className="breadcrumbs__item">
-                {text}
+              <li key={text} className="breadcrumbs__item" itemProp="itemListElement" itemScope  itemType="https://schema.org/ListItem">
+                <span itemProp="name">{text}</span>
+                <meta itemProp="position" content={`${index + 1}`} />
               </li>
             )
           }

--- a/components/CategoryNav.tsx
+++ b/components/CategoryNav.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from "next/router";
-import Link from 'next/link';
 import classnames from 'classnames';
 
 import { CategoryNoProducts, NavLink } from "../types";

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -6,10 +6,12 @@ interface Props {
 
 export default function FAQ({question, anchorId, children}: Props) {
   return (
-    <div className="faq" id={anchorId}>
-      <h2 className="faq__question">{question}</h2>
-      <div className="faq__answer">
-        {children}
+    <div className="faq" id={anchorId} itemScope itemProp="mainEntity" itemType="https://schema.org/Question">
+      <h2 className="faq__question" itemProp="name">{question}</h2>
+      <div className="faq__answer" itemScope itemProp="acceptedAnswer" itemType="https://schema.org/Answer">
+        <div itemProp="text">
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 export default function Footer() {
   return (
     <footer className="footer">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import Nav from './Nav';
 
 export default function Header() {

--- a/components/ImageCarousel.tsx
+++ b/components/ImageCarousel.tsx
@@ -8,22 +8,25 @@ interface Props {
 
 export default function ImageCarousel({ images }: Props) {
   return (
-    <Carousel
-      infiniteLoop
-      showStatus={false}
-      showIndicators={false}
-      swipeable
-      emulateTouch
-      className="image-carousel"
-      renderArrowPrev={renderArrow('previous')}
-      renderArrowNext={renderArrow('next')}
-    >
-      {
-        images.map(({ url_fullxfull, description }) => (
-          <img key={url_fullxfull} src={url_fullxfull} alt={description} />
-        ))
-      }
-    </Carousel>
+    <>
+      <link itemProp="image" href={images[0]['url_fullxfull']} />
+      <Carousel
+        infiniteLoop
+        showStatus={false}
+        showIndicators={false}
+        swipeable
+        emulateTouch
+        className="image-carousel"
+        renderArrowPrev={renderArrow('previous')}
+        renderArrowNext={renderArrow('next')}
+      >
+        {
+          images.map(({ url_fullxfull, description }, index) => (
+            <img key={url_fullxfull} src={url_fullxfull} alt={description} />
+          ))
+        }
+      </Carousel>
+    </>
   )
 }
 

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import classnames from 'classnames';
 

--- a/components/ProductItem.tsx
+++ b/components/ProductItem.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Product } from '../types';
 
 const NEW_IS_WITHIN_DAYS = 21;

--- a/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
+++ b/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
@@ -1,7 +1,6 @@
 import { InferGetStaticPropsType, GetStaticPathsResult } from 'next';
 import Head from 'next/head';
 import { useRouter } from "next/router";
-import Link from 'next/link';
 import htmlParser from 'html-react-parser';
 
 import shopData from '../../../shop-data.json';

--- a/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
+++ b/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
@@ -1,5 +1,6 @@
 import { InferGetStaticPropsType, GetStaticPathsResult } from 'next';
 import Head from 'next/head';
+import { useRouter } from "next/router";
 import Link from 'next/link';
 import htmlParser from 'html-react-parser';
 
@@ -27,22 +28,37 @@ export default function ProductPage({
       text: product.title
     }
   ];
+  const isTest = process.env.ENVIRONMENT === 'test';
+  const domain = isTest ? 'test.roseatecards.co.uk' : 'roseatecards.co.uk';
+  const { asPath } = useRouter();
   return (
     <div className="gel-wrap product-page">
       <Head>
         <title>{product.title} - {subCategoryInfo.name} - {categoryInfo.name} - Roseate Cards</title>
       </Head>
       <Breadcrumbs items={breadcrumbItems} />
-      <div className="gel-layout">
+      <div className="gel-layout" itemScope itemType="http://schema.org/Product">
+        <div itemProp="brand" itemType="http://schema.org/Brand" itemScope>
+          <meta itemProp="name" content="Roseate Cards" />
+        </div>
         <div className="gel-layout__item gel-1/2@m">
           <ImageCarousel images={product.images} />
         </div>
         <div className="gel-layout__item gel-1/2@m">
           <h1 className="page-title product-page__title">{product.title}</h1>
-          <p className="product-page__price">£{product.price}</p>
+          <meta itemProp="name" content={`${product.title} - Roseate Cards`} />
+          <span itemProp="offers" itemScope itemType="http://schema.org/Offer">
+            <link itemProp="url" href={`https://www.${domain}${asPath}`} />
+            <meta itemProp="priceCurrency" content="GBP" />
+            <meta itemProp="availability" content="https://schema.org/InStock" />
+            <meta itemProp="itemCondition" content="https://schema.org/NewCondition" />
+            <meta itemProp="price" content={product.price} />
+            <p className="product-page__price">£{product.price}</p>
+          </span>
           <a className="product-page__buy" href={product.url}>
             Buy on Etsy
           </a>
+          <meta itemProp="description" content={`${htmlParser(product.description.replace(/\n/g, ' '))}`} />
           <p className="product-page__description">
             {htmlParser(product.description.replace(/\n/g, '<br />'))}
           </p>

--- a/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
+++ b/pages/[categoryId]/[subCategoryId]/[productSlug].tsx
@@ -47,7 +47,7 @@ export default function ProductPage({
           <h1 className="page-title product-page__title">{product.title}</h1>
           <meta itemProp="name" content={`${product.title} - Roseate Cards`} />
           <span itemProp="offers" itemScope itemType="http://schema.org/Offer">
-            <link itemProp="url" href={`https://www.${domain}${asPath}`} />
+            <link itemProp="url" href={`https://${domain}${asPath}`} />
             <meta itemProp="priceCurrency" content="GBP" />
             <meta itemProp="availability" content="https://schema.org/InStock" />
             <meta itemProp="itemCondition" content="https://schema.org/NewCondition" />

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -9,7 +9,7 @@ export default function Contact() {
       </Head>
       <h1 className="page-title">FAQs</h1>
 
-      <div className="contact-page__faq">
+      <div className="contact-page__faq" itemScope itemType="https://schema.org/FAQPage">
         <FAQ anchorId="covid19" question="COVID-19 update">
           <p>Roseate Cards is still open and will remain open during the lockdown period as we can safely work from home! However, our shipping couriers are experiencing some delays which are unfortunately outside our control.</p>
           <p>Most orders take between 3-5 days, but there have been reports of orders taking up to 10 days to arrive. Please make sure you leave as much time as possible when placing your order!</p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 export default function Home() {
   return (
     <div className="gel-wrap home-page">


### PR DESCRIPTION
Add structured data markup for products, FAQ and product breadcrumbs

Tested using https://search.google.com/test/rich-results?utm_campaign=sdtt&utm_medium=message

Google docs on structured data:

- https://developers.google.com/search/docs/data-types/product
- https://developers.google.com/search/docs/data-types/faqpage
- https://developers.google.com/search/docs/data-types/breadcrumb