### PR TITLE
Change 'new' label logic to look at original creation date

### DIFF
--- a/scripts/generateShopData.js
+++ b/scripts/generateShopData.js
@@ -155,7 +155,7 @@ async function getCleanListing(listing, categoryId, subCategoryId, variationName
     description: entities.decode(listingDescription).trim(),
     url: listing.url,
     price: listing.price,
-    created: listing.creation_tsz * 1000,
+    created: listing.original_creation_tsz * 1000,
     lastModified: listing.last_modified_tsz * 1000,
     featuredRank: listing.featured_rank,
     images


### PR DESCRIPTION
The current logic looks at 'creation date' which is updated every time a listing is renewed. Given this happens every 4 months OR when a product is sold, this means a lot of products are marked as 'new' wrongly.

Change the logic to look at original creation date instead.